### PR TITLE
Update three and troika-three-text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,27 @@
 {
   "name": "three-perf",
-  "version": "1.0.0",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "three-perf",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "MIT",
+      "dependencies": {
+        "troika-three-text": "^0.52.0",
+        "tweakpane": "^3.1.10"
+      },
       "devDependencies": {
-        "@types/three": "^0.152.1",
+        "@types/three": "^0.170.0",
         "express": "^4.18.2",
         "fs": "^0.0.1-security",
         "path": "^0.12.7",
-        "three": "^0.153.0",
-        "troika-three-text": "^0.47.2",
-        "tweakpane": "^3.1.10",
         "typescript": "^5.1.3",
         "vite": "^4.3.9"
+      },
+      "peerDependencies": {
+        "three": ">=0.170"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -373,10 +377,11 @@
       }
     },
     "node_modules/@tweenjs/tween.js": {
-      "version": "18.6.4",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-18.6.4.tgz",
-      "integrity": "sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ==",
-      "dev": true
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stats.js": {
       "version": "0.17.0",
@@ -385,16 +390,18 @@
       "dev": true
     },
     "node_modules/@types/three": {
-      "version": "0.152.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.152.1.tgz",
-      "integrity": "sha512-PMOCQnx9JRmq+2OUGTPoY9h1hTWD2L7/nmuW/SyNq1Vbq3Lwt3MNdl3wYSa4DvLTGv62NmIXD9jYdAOwohwJyw==",
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@tweenjs/tween.js": "~18.6.4",
+        "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
         "@types/webxr": "*",
-        "fflate": "~0.6.9",
-        "lil-gui": "~0.17.0"
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
       }
     },
     "node_modules/@types/webxr": {
@@ -402,6 +409,13 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.2.tgz",
       "integrity": "sha512-szL74BnIcok9m7QwYtVmQ+EdIKwbjPANudfuvDrAF8Cljg9MKUlIoc1w5tjj9PMpeSH3U1Xnx//czQybJ0EfSw==",
       "dev": true
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.51",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.51.tgz",
+      "integrity": "sha512-ktR3u64NPjwIViNCck+z9QeyN0iPkQCUOQ07ZCV1RzlkfP+olLTeEZ95O1QHS+v4w9vJeY9xj/uJuSphsHy5rQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -426,7 +440,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.2.tgz",
       "integrity": "sha512-rzSy/k7WdX5zOyeHHCOixGXbCHkyogkxPKL2r8QtzHmVQDiWCXUWa18bLdMWT9CYMLOYTjWpTHawuev2ouYJVw==",
-      "dev": true,
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -651,10 +664,11 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
-      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
-      "dev": true
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "1.2.0",
@@ -818,12 +832,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/lil-gui": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.17.0.tgz",
-      "integrity": "sha512-MVBHmgY+uEbmJNApAaPbtvNh1RCAeMnKym82SBjtp5rODTYKWtM+MXHCifLe2H2Ti1HuBGBtK/5SyG4ShQ3pUQ==",
-      "dev": true
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -838,6 +846,13 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -1059,7 +1074,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1190,10 +1204,11 @@
       }
     },
     "node_modules/three": {
-      "version": "0.153.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.153.0.tgz",
-      "integrity": "sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg==",
-      "dev": true
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -1205,14 +1220,14 @@
       }
     },
     "node_modules/troika-three-text": {
-      "version": "0.47.2",
-      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.47.2.tgz",
-      "integrity": "sha512-qylT0F+U7xGs+/PEf3ujBdJMYWbn0Qci0kLqI5BJG2kW1wdg4T1XSxneypnF05DxFqJhEzuaOR9S2SjiyknMng==",
-      "dev": true,
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.2.tgz",
+      "integrity": "sha512-UGYwjKnR8RgmyOIpo0/KiSW0wySQ155BQXNLoSWA1liKzXG+RyHM+dvTIDawHGVQcqjqyunFlVY32xm/HDqjpw==",
+      "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.2",
-        "troika-three-utils": "^0.47.2",
-        "troika-worker-utils": "^0.47.2",
+        "troika-three-utils": "^0.52.0",
+        "troika-worker-utils": "^0.52.0",
         "webgl-sdf-generator": "1.1.1"
       },
       "peerDependencies": {
@@ -1220,25 +1235,24 @@
       }
     },
     "node_modules/troika-three-utils": {
-      "version": "0.47.2",
-      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.47.2.tgz",
-      "integrity": "sha512-/28plhCxfKtH7MSxEGx8e3b/OXU5A0xlwl+Sbdp0H8FXUHKZDoksduEKmjQayXYtxAyuUiCRunYIv/8Vi7aiyg==",
-      "dev": true,
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.0.tgz",
+      "integrity": "sha512-00oxqIIehtEKInOTQekgyknBuRUj1POfOUE2q1OmL+Xlpp4gIu+S0oA0schTyXsDS4d9DkR04iqCdD40rF5R6w==",
+      "license": "MIT",
       "peerDependencies": {
         "three": ">=0.125.0"
       }
     },
     "node_modules/troika-worker-utils": {
-      "version": "0.47.2",
-      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.47.2.tgz",
-      "integrity": "sha512-mzss4MeyzUkYBppn4x5cdAqrhBHFEuVmMMgLMTyFV23x6GvQMyo+/R5E5Lsbrt7WSt5RfvewjcwD1DChRTA9lA==",
-      "dev": true
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
     },
     "node_modules/tweakpane": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-3.1.10.tgz",
       "integrity": "sha512-rqwnl/pUa7+inhI2E9ayGTqqP0EPOOn/wVvSWjZsRbZUItzNShny7pzwL3hVlaN4m9t/aZhsP0aFQ9U5VVR2VQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/cocopon"
       }
@@ -1356,8 +1370,7 @@
     "node_modules/webgl-sdf-generator": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
-      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
-      "dev": true
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     "url": "https://github.com/TheoTheDev/three-perf/issues"
   },
   "dependencies": {
-    "troika-three-text": "^0.47.2",
+    "troika-three-text": "^0.52.0",
     "tweakpane": "^3.1.10"
   },
   "devDependencies": {
-    "@types/three": "^0.152.1",
+    "@types/three": "^0.170.0",
     "express": "^4.18.2",
     "fs": "^0.0.1-security",
     "path": "^0.12.7",
@@ -54,6 +54,6 @@
     "vite": "^4.3.9"
   },
   "peerDependencies": {
-    "three": ">=0.151"
+    "three": ">=0.170"
   }
 }


### PR DESCRIPTION
In Threlte, we ran into an issue where three-perf was using outdated troika-three-text that was not compatible with three 170 and our internal version of troika. 

I bumped the versions of three and troika, but it would be nice to somehow support a wider range of threejs versions in the future. Maybe using a different lib or just html for three-perf UI?